### PR TITLE
Fix spelling of 'getScratchPercent' method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It is easy to get the scratched percent.
  
 ######Example
   
-    let scratch_percent:Double = ScratchCard.getScarachPercent()
+    let scratch_percent:Double = ScratchCard.getScratchPercent()
       
 
 ##License


### PR DESCRIPTION
This code is saving my bacon on a project right now - thanks for publishing it! Just a minor fix to the spelling in the README.
